### PR TITLE
Fix equipment_events error

### DIFF
--- a/thermostat_api_server.py
+++ b/thermostat_api_server.py
@@ -362,7 +362,7 @@ class MyHttpRequestHandler(BaseHTTPRequestHandler):
                 self.send_empty_200()
 
             elif "/equipment_events" in final_locator:
-                if received_message['active'] == "on":
+                if "active" in received_message and received_message['active'] == "on":
                     state = f"{received_message['localtime'][1:]}: {received_message['description']}"
                 else:
                     state = "No Active Event"


### PR DESCRIPTION
It appears that the /equipment_events endpoint can result in an error.  I'm unsure if this was caused by a recent update to the firmware on the thermostat (I went from 4.02 to 5.02) or was always there. When it errors, the script won't respond properly to the thermostat so the thermostat waits for a long time before trying to reconnect and do the regular /status, /odu_status calls so the integration looks like it's not responding anymore. The value the thermostat sends when there are no active events is now "{'equipment_events': None}".  I've changed line 365 to check for the existence of received_message['active'] before checking its value, but not sure if 'active' ever shows up on the new firmware.  I'll see if I can catch it if/when there's a new event.

The full error:

```
Exception happened during processing of request from ('192.168.200.191', 4104) Traceback (most recent call last):
  File "/usr/local/lib/python3.8/socketserver.py", line 683, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/local/lib/python3.8/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/local/lib/python3.8/socketserver.py", line 747, in __init__
    self.handle()
  File "/usr/local/lib/python3.8/http/server.py", line 437, in handle
    self.handle_one_request()
  File "/usr/local/lib/python3.8/http/server.py", line 423, in handle_one_request
    method()
  File "/usr/bin/thermostat_api_server.py", line 365, in do_POST
    if received_message['active'] == "on":
KeyError: 'active'
```